### PR TITLE
Add time unit picker for goal deadline

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -9,22 +9,16 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:savings_jar_app/main.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  testWidgets('Shows goal amount field when no goal is set',
+      (WidgetTester tester) async {
+    SharedPreferences.setMockInitialValues({});
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+    await tester.pumpWidget(const SavingsJarApp());
+    await tester.pumpAndSettle();
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.widgetWithText(TextField, 'Целевая сумма'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add `TimeUnit` enum and selected unit state
- handle deadline input according to chosen time unit
- add dropdown to choose hours, days, months or years when entering the deadline

## Testing
- `flutter test test/widget_test.dart` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684eb6dc65b4832e962fe892fbffedec